### PR TITLE
MAINT: update checkout version (to fix warning in GHA)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ jobs:
     name: audit
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: check filesystem
         run: |

--- a/.github/workflows/feedstocks.yml
+++ b/.github/workflows/feedstocks.yml
@@ -14,9 +14,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/keepalive.yaml
+++ b/.github/workflows/keepalive.yaml
@@ -8,5 +8,5 @@ jobs:
     name: Cronjob based github action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gautamkrishnar/keepalive-workflow@v1

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/pypi_mapping.yml
+++ b/.github/workflows/pypi_mapping.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/update_status_page.yml
+++ b/.github/workflows/update_status_page.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
Trivial PR for fixing the warning I noticed today while checkout out one of the actions log.