### PR TITLE
Update github workflows as companion to regro/cf-scripts#1598

### DIFF
--- a/.github/delete-old-runs-env.yml
+++ b/.github/delete-old-runs-env.yml
@@ -1,0 +1,34 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - anaconda-client
+  - bzip2
+  - click
+  - conda
+  - conda-build
+  - conda-package-handling
+  - cryptography
+  - curl
+  - fastapi
+  - flake8
+  - git
+  - gitpython
+  - joblib
+  - license-expression
+  - pip
+  - pygithub
+  - pyjwt
+  - pynacl
+  - pytest
+  - python-rapidjson
+  - pytz
+  - pyyaml
+  - rapidjson
+  - requests
+  - tenacity
+  - tqdm
+  - typer
+  - wget
+  - uvicorn

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -39,7 +39,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 5
+          conda-forge-tick2 audit
           popd
         env:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1
+          conda-forge-tick2 deploy
 
           popd
         env:

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -53,7 +53,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 1 ${BOT_CLI_ARGS}
+          conda-forge-tick2 make_graph ${BOT_CLI_ARGS}
           popd
         env:
           USERNAME: regro-cf-autotick-bot
@@ -71,7 +71,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 3 ${BOT_CLI_ARGS}
+          conda-forge-tick2 auto-tick ${BOT_CLI_ARGS}
           popd
         env:
           USERNAME: regro-cf-autotick-bot
@@ -94,7 +94,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1 ${BOT_CLI_ARGS}
+          conda-forge-tick2 deploy ${BOT_CLI_ARGS}
 
           popd
         env:

--- a/.github/workflows/delete-old-runs.yml
+++ b/.github/workflows/delete-old-runs.yml
@@ -9,44 +9,12 @@ jobs:
     name: delete-old-runs
     runs-on: "ubuntu-latest"
     steps:
-      - name: get env file
-        shell: bash -l {0}
-        run: |
-          wget https://raw.githubusercontent.com/conda-forge/repodata-tools/main/environment.yml
-
       - name: install micromamba
         uses: mamba-org/provision-with-micromamba@main
+        environment-file: .github/delete-old-runs-env.yml
 
       - name: delete runs
         shell: bash -l {0}
-        run: |
-          echo "\
-          import github
-          import os
-          import sys
-          import requests
-          import datetime
-          import time
-          
-          gh = github.Github(os.environ['GITHUB_TOKEN'])
-          r = gh.get_repo('regro/autotick-bot')
-          done = 0
-          for w in r.get_workflows():
-              for _ in range(10):
-                  for rn in w.get_runs():
-                      if rn.status == 'completed' and (
-                          datetime.datetime.utcnow() - rn.updated_at > datetime.timedelta(days=365)
-                      ):
-                          requests.delete(
-                              rn.url, 
-                              headers={'Authorization': 'Bearer ' + os.environ['GITHUB_TOKEN']},
-                          )
-                          done += 1
-                          time.sleep(2)
-                      if done == 200:
-                          sys.exit(0)
-          " > del_old_runs.py
-          
-          python del_old_runs.py
+        run: python scripts/delete_old_runs.py
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOTICK_BOT_TOKEN }}

--- a/.github/workflows/feedstocks.yml
+++ b/.github/workflows/feedstocks.yml
@@ -45,7 +45,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 0
+          conda-forge-tick2 all-feedstocks
           popd
         env:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1
+          conda-forge-tick2 deploy
 
           popd
         env:

--- a/.github/workflows/keepalive.yaml
+++ b/.github/workflows/keepalive.yaml
@@ -2,6 +2,9 @@ name: keepalive
 on:
   schedule:
     - cron: "0 0 * * *"
+# the keepalive-workflow is a GitHub action to prevent GitHub from suspending
+# your cronjob based triggers due to repository inactivity
+
 
 jobs:
   cronjob-based-github-action:

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -46,7 +46,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run 6
+          conda-forge-tick2 update-prs
           popd
         env:
           USERNAME: regro-cf-autotick-bot
@@ -61,7 +61,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1
+          conda-forge-tick2 deploy
 
           popd
         env:

--- a/.github/workflows/pypi_mapping.yml
+++ b/.github/workflows/pypi_mapping.yml
@@ -42,7 +42,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 7
+          conda-forge-tick2 mappings
           popd
         env:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1
+          conda-forge-tick2 deploy
 
           popd
         env:

--- a/.github/workflows/update_status_page.yml
+++ b/.github/workflows/update_status_page.yml
@@ -41,7 +41,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 4
+          conda-forge-tick2 status-report
           popd
         env:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1
+          conda-forge-tick2 deploy
 
           popd
         env:

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -43,7 +43,7 @@ jobs:
           pushd cf-graph
           conda activate run_env
 
-          conda-forge-tick --run 2
+          conda-forge-tick2 update-upstream-versions
           popd
         env:
           PASSWORD: ${{ secrets.AUTOTICK_BOT_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
 
           export CIRCLE_BUILD_URL="https://github.com/regro/autotick-bot/actions/runs/${RUN_ID}"
           export CIRCLE_BUILD_NUM="actually-actions-${RUN_ID}"
-          conda-forge-tick --run -1
+          conda-forge-tick2 deploy
 
           popd
         env:

--- a/scripts/delete_old_runs.py
+++ b/scripts/delete_old_runs.py
@@ -1,0 +1,41 @@
+import github
+import os
+import sys
+import requests
+import datetime
+import time
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def main(token: str = "", max_runs: int = 200):
+    token = token or os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        raise RuntimeError("Requires GITHUB_TOKEN env var to be set")
+
+    gh = github.Github(token)
+    r = gh.get_repo("regro/autotick-bot")
+    done = 0
+    for w in r.get_workflows():
+        for _ in range(10):
+            for rn in w.get_runs():
+                if rn.status == "completed" and (
+                    datetime.datetime.utcnow() - rn.updated_at
+                    > datetime.timedelta(days=365)
+                ):
+                    requests.delete(
+                        rn.url,
+                        headers={
+                            "Authorization": "Bearer " + os.environ["GITHUB_TOKEN"]
+                        },
+                    )
+                    done += 1
+                    time.sleep(2)
+                if done >= max_runs:
+                    return
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
companion PR to https://github.com/regro/cf-scripts/pull/1598.

also the following unrelated changes:
- noticed that the environment file that was being pulled in delete-old-runs.yml was from an archived repository.
- full python script embedded in yaml is super prone to bugs. pulled that out and made it into a proper CLI for maintainability